### PR TITLE
AbilityInventoryManager now updates run augments

### DIFF
--- a/Assets/Scenes/Rodrigo/AbilityTagTest.unity
+++ b/Assets/Scenes/Rodrigo/AbilityTagTest.unity
@@ -347,14 +347,17 @@ PrefabInstance:
     - {fileID: 6615919859577196368, guid: 0c830a5c172407e4a8223753fb3fd619, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8263862798321204670, guid: 0c830a5c172407e4a8223753fb3fd619, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 678143430}
   m_SourcePrefab: {fileID: 100100000, guid: 0c830a5c172407e4a8223753fb3fd619, type: 3}
 --- !u!114 &115705338 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6086381338991058192, guid: 0c830a5c172407e4a8223753fb3fd619, type: 3}
   m_PrefabInstance: {fileID: 115705337}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 678143420}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ab4a0225d7e19f04caad9ce18096aa14, type: 3}
@@ -687,7 +690,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 573003372959300552, guid: 0c830a5c172407e4a8223753fb3fd619, type: 3}
   m_PrefabInstance: {fileID: 115705337}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 678143420}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 34526342824b52f4eb2b8d8600c67cee, type: 3}
@@ -698,12 +701,30 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4451322402477620099, guid: 0c830a5c172407e4a8223753fb3fd619, type: 3}
   m_PrefabInstance: {fileID: 115705337}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 678143420}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b508dc3b1d4391f4f830037fcced6474, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &678143420 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8263862798321204670, guid: 0c830a5c172407e4a8223753fb3fd619, type: 3}
+  m_PrefabInstance: {fileID: 115705337}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &678143430
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 678143420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6818fdf07ab87dc45b472730d09a4fc3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  augmentManager: {fileID: 0}
 --- !u!1 &867298787
 GameObject:
   m_ObjectHideFlags: 0
@@ -21179,6 +21200,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1518116029080005498, guid: fd90c421dcca4f646acc217f17b13fa9, type: 3}
+      propertyPath: intialHealth
+      value: 100
+      objectReference: {fileID: 0}
     - target: {fileID: 1866140760894025706, guid: fd90c421dcca4f646acc217f17b13fa9, type: 3}
       propertyPath: speed
       value: 15

--- a/Assets/Scenes/Rodrigo/AbilityTagTest.unity
+++ b/Assets/Scenes/Rodrigo/AbilityTagTest.unity
@@ -178,7 +178,7 @@ PrefabInstance:
     - target: {fileID: 4451322402477620099, guid: 0c830a5c172407e4a8223753fb3fd619, type: 3}
       propertyPath: dashAbility
       value: 
-      objectReference: {fileID: 11400000, guid: 7ed3257df13a0594fa64d5a6895f3c62, type: 2}
+      objectReference: {fileID: 11400000, guid: 77ee3af21df94a947a3dcd8341fbbdac, type: 2}
     - target: {fileID: 4451322402477620099, guid: 0c830a5c172407e4a8223753fb3fd619, type: 3}
       propertyPath: abilityCursor
       value: 
@@ -194,11 +194,11 @@ PrefabInstance:
     - target: {fileID: 4451322402477620099, guid: 0c830a5c172407e4a8223753fb3fd619, type: 3}
       propertyPath: startingAbilities.Array.data[0].ability
       value: 
-      objectReference: {fileID: 11400000, guid: 1f9323a04fe5d6c4cae7914b97d5261c, type: 2}
+      objectReference: {fileID: 11400000, guid: 7cdb47186fde68a4ca7fdd31933c5a81, type: 2}
     - target: {fileID: 4451322402477620099, guid: 0c830a5c172407e4a8223753fb3fd619, type: 3}
       propertyPath: startingAbilities.Array.data[1].ability
       value: 
-      objectReference: {fileID: 11400000, guid: 8608b9fd89d27124b925db2bc02fb71e, type: 2}
+      objectReference: {fileID: 0}
     - target: {fileID: 5731619865225059497, guid: 0c830a5c172407e4a8223753fb3fd619, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -20932,7 +20932,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 13016b50a09b748d09ff70cf8453503b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  player: {fileID: 115705338}
+  current: {fileID: 0}
 --- !u!4 &1801145472
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/ScriptableObjects/AbilityWrapper.meta
+++ b/Assets/ScriptableObjects/AbilityWrapper.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 98aa07c1c16eaef42bed610dfecfaacd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/AbilityWrapper/Blink Dagger Ability Wrapper.asset
+++ b/Assets/ScriptableObjects/AbilityWrapper/Blink Dagger Ability Wrapper.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 537c85cce35073f43ae081edbcef38ef, type: 3}
+  m_Name: Blink Dagger Ability Wrapper
+  m_EditorClassIdentifier: 
+  activeAbility: {fileID: 11400000, guid: 1f9323a04fe5d6c4cae7914b97d5261c, type: 2}
+  passiveAbility: {fileID: 11400000, guid: 1ec54eb4ade3c4c94bd817e06a8ec2a5, type: 2}

--- a/Assets/ScriptableObjects/AbilityWrapper/Blink Dagger Ability Wrapper.asset.meta
+++ b/Assets/ScriptableObjects/AbilityWrapper/Blink Dagger Ability Wrapper.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7cdb47186fde68a4ca7fdd31933c5a81
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/AbilityWrapper/Dash Ability Wrapper.asset
+++ b/Assets/ScriptableObjects/AbilityWrapper/Dash Ability Wrapper.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ce8c89705e75294fbcf03117eb7dd5c, type: 3}
+  m_Name: Dash Ability Wrapper
+  m_EditorClassIdentifier: 
+  activeAbility: {fileID: 11400000, guid: 7ed3257df13a0594fa64d5a6895f3c62, type: 2}
+  passiveAbility: {fileID: 11400000, guid: 839cceae59c8a4e939ff8d88a676bff1, type: 2}

--- a/Assets/ScriptableObjects/AbilityWrapper/Dash Ability Wrapper.asset.meta
+++ b/Assets/ScriptableObjects/AbilityWrapper/Dash Ability Wrapper.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 77ee3af21df94a947a3dcd8341fbbdac
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/AbilityWrapper/Projectile Ability Wrapper.asset
+++ b/Assets/ScriptableObjects/AbilityWrapper/Projectile Ability Wrapper.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8758510c72d90c47874e8a5fae182c6, type: 3}
+  m_Name: Projectile Ability Wrapper
+  m_EditorClassIdentifier: 
+  activeAbility: {fileID: 0}
+  passiveAbility: {fileID: 0}

--- a/Assets/ScriptableObjects/AbilityWrapper/Projectile Ability Wrapper.asset.meta
+++ b/Assets/ScriptableObjects/AbilityWrapper/Projectile Ability Wrapper.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f95c090da30fc34cb3b55737e8254fc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/AbilityWrapper/Ray Cast Ability Wrapper.asset
+++ b/Assets/ScriptableObjects/AbilityWrapper/Ray Cast Ability Wrapper.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e1af4305abedd294294f103825f4d0c4, type: 3}
+  m_Name: Ray Cast Ability Wrapper
+  m_EditorClassIdentifier: 
+  activeAbility: {fileID: 0}
+  passiveAbility: {fileID: 0}

--- a/Assets/ScriptableObjects/AbilityWrapper/Ray Cast Ability Wrapper.asset.meta
+++ b/Assets/ScriptableObjects/AbilityWrapper/Ray Cast Ability Wrapper.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 68ca8abe57bdf9046aa4ead7eb505518
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Ability System/AbilityHolder.cs
+++ b/Assets/Scripts/Ability System/AbilityHolder.cs
@@ -77,25 +77,25 @@ public class AbilityHolder : MonoBehaviour
     void Update()
     {  
         if (dashAbility == null) {
-            dashAbility = abilityManager.GetHotbarAbilities()[0].GetAbility();
+            dashAbility = abilityManager.GetHotbarAbilities()[0].GetAbility().getActiveAbility();
             dashAbilityImage = abilityManager.GetHotbarSlots()[0].GetComponent<Image>();
         }
 
         if (abilityManager.GetHotbarAbilities()[1].GetAbility() != null) {
-            ability1 = abilityManager.GetHotbarAbilities()[1].GetAbility();
+            ability1 = abilityManager.GetHotbarAbilities()[1].GetAbility().getActiveAbility();
             ability1Img = abilityManager.GetHotbarSlots()[1].GetComponent<Image>();
 
         }
 
         if (abilityManager.GetHotbarAbilities()[2].GetAbility() != null) {
-            ability2 = abilityManager.GetHotbarAbilities()[2].GetAbility();
+            ability2 = abilityManager.GetHotbarAbilities()[2].GetAbility().getActiveAbility();
             ability2Img = abilityManager.GetHotbarSlots()[2].GetComponent<Image>();
 
 
         }
 
         if (abilityManager.GetHotbarAbilities()[3].GetAbility() != null) {
-            ability3 = abilityManager.GetHotbarAbilities()[3].GetAbility();
+            ability3 = abilityManager.GetHotbarAbilities()[3].GetAbility().getActiveAbility();
             ability3Img = abilityManager.GetHotbarSlots()[3].GetComponent<Image>();
 
 

--- a/Assets/Scripts/Ability System/AbilityInventoryManager.cs
+++ b/Assets/Scripts/Ability System/AbilityInventoryManager.cs
@@ -106,6 +106,10 @@ public class AbilityInventoryManager : MonoBehaviour
             SlotClass slot = abilities[i];
             if (slot.isClear() == false) {
                 Debug.Log("Found Ability <" + slot.GetAbility() + "> in abilities list");
+                if (slot.GetAbility().getPassiveAbility() == null) {
+                    Debug.Log("[AbilityInventoryManager] Ability " + slot.GetAbility() + " has no associated passive. This shouldn't happen");
+                    continue;
+                }
                 augmentManager.addAugment(slot.GetAbility().getPassiveAbility());
             };
         }

--- a/Assets/Scripts/Ability System/AbilityInventoryManager.cs
+++ b/Assets/Scripts/Ability System/AbilityInventoryManager.cs
@@ -6,6 +6,9 @@ using UnityEngine.UI;
 
 public class AbilityInventoryManager : MonoBehaviour
 {
+
+    [SerializeField] private bool DEBUG = false;
+
     [SerializeField] private GameObject abilityCursor;
     [SerializeField] private GameObject slotHolder;
     [SerializeField] private GameObject hotbarSlotHolder;
@@ -105,9 +108,9 @@ public class AbilityInventoryManager : MonoBehaviour
         for (int i = 0; i < abilities.Length - NUMBER_OF_ABILITIES; i++) {
             SlotClass slot = abilities[i];
             if (slot.isClear() == false) {
-                Debug.Log("Found Ability <" + slot.GetAbility() + "> in abilities list");
+                if (DEBUG) Debug.Log("Found Ability <" + slot.GetAbility() + "> in abilities list");
                 if (slot.GetAbility().getPassiveAbility() == null) {
-                    Debug.Log("[AbilityInventoryManager] Ability " + slot.GetAbility() + " has no associated passive. This shouldn't happen");
+                    if (DEBUG) Debug.Log("[AbilityInventoryManager] Ability " + slot.GetAbility() + " has no associated passive. This shouldn't happen");
                     continue;
                 }
                 augmentManager.addAugment(slot.GetAbility().getPassiveAbility());
@@ -138,11 +141,11 @@ public class AbilityInventoryManager : MonoBehaviour
         bool allClear = true;
         foreach (SlotClass slot in abilities) {
             if (slot.isClear() == false) {
-                Debug.Log("[AbilityInventoryManager/RefreshUI] Found ability <" + slot + "> in passive List");
+                if (DEBUG) Debug.Log("[AbilityInventoryManager/RefreshUI] Found ability <" + slot + "> in passive List");
                 allClear = false;
             }
         }
-        if (allClear) Debug.Log("[AbilityInventoryManager/RefreshUI] All slots cleared");
+        if (allClear) if (DEBUG) Debug.Log("[AbilityInventoryManager/RefreshUI] All slots cleared");
         RefreshEnabledAugments();
         RefreshHotBar();
     }

--- a/Assets/Scripts/Ability System/AbilityInventoryManager.cs
+++ b/Assets/Scripts/Ability System/AbilityInventoryManager.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -9,20 +10,22 @@ public class AbilityInventoryManager : MonoBehaviour
     [SerializeField] private GameObject slotHolder;
     [SerializeField] private GameObject hotbarSlotHolder;
 
-    [SerializeField] private Ability newAbility;
-    [SerializeField] private Ability abilityToDiscard;
+    [SerializeField] private AbilityWrapper newAbility;
+    [SerializeField] private AbilityWrapper abilityToDiscard;
 
 
     //public List<Ability> abilities11 = new List<Ability>();
 
     [SerializeField] private SlotClass[] startingAbilities;
-    [SerializeField] private Ability dashAbility;
+    [SerializeField] private AbilityWrapper dashAbility;
     private SlotClass[] abilities;
     private SlotClass[] hotbarAbilities;
 
     private GameObject[] slots;
     private GameObject[] hotbarSlots;
     private static int NUMBER_OF_ABILITIES;
+
+    private AugmentManager augmentManager;
 
 
     private SlotClass movingSlot;
@@ -65,9 +68,12 @@ public class AbilityInventoryManager : MonoBehaviour
         }
 
         // Add the dash ability image to the hotbar
-        hotbarSlots[0].transform.GetChild(0).GetComponent<Image>().sprite = dashAbility.aSprite;
+        hotbarSlots[0].transform.GetChild(0).GetComponent<Image>().sprite = dashAbility.getActiveAbility().aSprite;
         hotbarSlots[0].transform.GetChild(0).GetComponent<Image>().enabled = true;
 
+        // Add AugmentManager reference so we can update augments
+        augmentManager = gameObject.GetComponent<AugmentManager>();
+        
         RefreshUI();    
         Add(newAbility);
         Remove(abilityToDiscard);
@@ -77,7 +83,7 @@ public class AbilityInventoryManager : MonoBehaviour
         abilityCursor.SetActive(isMovingItem);
         abilityCursor.transform.position = Input.mousePosition; 
         if (isMovingItem) {
-            abilityCursor.GetComponent<Image>().sprite = movingSlot.GetAbility().aSprite;
+            abilityCursor.GetComponent<Image>().sprite = movingSlot.GetAbility().getActiveAbility().aSprite;
         }
 
         if (Input.GetMouseButtonDown(0)) 
@@ -88,8 +94,27 @@ public class AbilityInventoryManager : MonoBehaviour
                 BeginItemMove();
             }
         }
+
     }
 
+    #region Active / Passive Utils
+
+    public void RefreshEnabledAugments() {
+
+        augmentManager.clearAugments();
+        for (int i = 0; i < abilities.Length - NUMBER_OF_ABILITIES; i++) {
+            SlotClass slot = abilities[i];
+            if (slot.isClear() == false) {
+                Debug.Log("Found Ability <" + slot.GetAbility() + "> in abilities list");
+                augmentManager.addAugment(slot.GetAbility().getPassiveAbility());
+            };
+        }
+        // Realistically we want this to be only applied to the AugmentManager attached to the player, so this is safe
+        
+
+    }
+
+    #endregion
 
     #region Inventory Utils
 
@@ -98,7 +123,7 @@ public class AbilityInventoryManager : MonoBehaviour
         for (int i = 0; i < slots.Length; i++) {
             try {
                 //slots[i].transform.GetChild(0).GetComponent<Image>().sprite = abilities[i].GetAbility().aSprite;
-                slots[i].transform.GetChild(0).GetComponent<Image>().sprite = abilities[i].GetAbility().aSprite;
+                slots[i].transform.GetChild(0).GetComponent<Image>().sprite = abilities[i].GetAbility().getActiveAbility().aSprite;
                 slots[i].transform.GetChild(0).GetComponent<Image>().enabled = true;
             } catch {
                 slots[i].transform.GetChild(0).GetComponent<Image>().sprite = null;
@@ -106,27 +131,36 @@ public class AbilityInventoryManager : MonoBehaviour
             }
         }
 
+        bool allClear = true;
+        foreach (SlotClass slot in abilities) {
+            if (slot.isClear() == false) {
+                Debug.Log("[AbilityInventoryManager/RefreshUI] Found ability <" + slot + "> in passive List");
+                allClear = false;
+            }
+        }
+        if (allClear) Debug.Log("[AbilityInventoryManager/RefreshUI] All slots cleared");
+        RefreshEnabledAugments();
         RefreshHotBar();
     }
 
     public void RefreshHotBar() 
     {
         // Refresh the dash ability on the hotbar
-        hotbarAbilities[0].GetAbility().Init();
-        hotbarAbilities[0].GetAbility().SetState(AbilityState.ready);
+        hotbarAbilities[0].GetAbility().getActiveAbility().Init();
+        hotbarAbilities[0].GetAbility().getActiveAbility().SetState(AbilityState.ready);
         hotbarSlots[0].transform.GetChild(0).GetComponent<Image>().fillAmount = 0;
 
         // Start at 1 to account for the dash ability taking up a slot
         for (int i = 1; i < hotbarSlots.Length; i++) {
             try {
                 //slots[i].transform.GetChild(0).GetComponent<Image>().sprite = abilities[i].GetAbility().aSprite;
-                hotbarSlots[i].transform.GetChild(0).GetComponent<Image>().sprite = abilities[(i - 1) + NUMBER_OF_ABILITIES * 2].GetAbility().aSprite;
+                hotbarSlots[i].transform.GetChild(0).GetComponent<Image>().sprite = abilities[(i - 1) + NUMBER_OF_ABILITIES * 2].GetAbility().getActiveAbility().aSprite;
                 hotbarSlots[i].transform.GetChild(0).GetComponent<Image>().enabled = true;
                 hotbarAbilities[i] = abilities[(i - 1) + NUMBER_OF_ABILITIES * 2];
 
                 if (hotbarAbilities[i].GetAbility() != null) {
-                    hotbarAbilities[i].GetAbility().Init();
-                    hotbarAbilities[i].GetAbility().SetState(AbilityState.ready);
+                    hotbarAbilities[i].GetAbility().getActiveAbility().Init();
+                    hotbarAbilities[i].GetAbility().getActiveAbility().SetState(AbilityState.ready);
                     hotbarSlots[i].transform.GetChild(0).GetComponent<Image>().fillAmount = 0;
                 }
 
@@ -138,7 +172,7 @@ public class AbilityInventoryManager : MonoBehaviour
     }
 
     // Update is called once per frame
-    public bool Add(Ability ability)
+    public bool Add(AbilityWrapper ability)
     {
         //abilities.Add(ability);
         SlotClass slot = Contains(ability);
@@ -157,7 +191,7 @@ public class AbilityInventoryManager : MonoBehaviour
         return true;
     }
 
-    public bool Remove(Ability ability)
+    public bool Remove(AbilityWrapper ability)
     {
         //abilities.Remove(ability); 
         SlotClass temp = Contains(ability);
@@ -180,7 +214,7 @@ public class AbilityInventoryManager : MonoBehaviour
 
     }
 
-    public SlotClass Contains(Ability ability) 
+    public SlotClass Contains(AbilityWrapper ability) 
     {
         for (int i = 0; i < abilities.Length; i++) {
             if (abilities[i].GetAbility() == ability) {

--- a/Assets/Scripts/Ability System/AbilityWrappers.meta
+++ b/Assets/Scripts/Ability System/AbilityWrappers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c93afcc52bc30c547b6aa55a8a37b880
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Ability System/AbilityWrappers/AbilityWrapper.cs
+++ b/Assets/Scripts/Ability System/AbilityWrappers/AbilityWrapper.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public abstract class AbilityWrapper : ScriptableObject
+{
+    [SerializeField]
+    private Ability activeAbility;
+
+    [SerializeField]
+    private Augment passiveAbility;
+
+    public Ability getActiveAbility() { 
+        return activeAbility;
+    }
+
+    public Augment getPassiveAbility() {
+        return passiveAbility;
+    }
+}

--- a/Assets/Scripts/Ability System/AbilityWrappers/AbilityWrapper.cs.meta
+++ b/Assets/Scripts/Ability System/AbilityWrappers/AbilityWrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a3a1741f2560c045b820fac80d7d29b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Ability System/AbilityWrappers/BlinkDaggerAbilityWrapper.cs
+++ b/Assets/Scripts/Ability System/AbilityWrappers/BlinkDaggerAbilityWrapper.cs
@@ -1,0 +1,6 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu]
+public class BlinkDaggerAbilityWrapper : AbilityWrapper {}

--- a/Assets/Scripts/Ability System/AbilityWrappers/BlinkDaggerAbilityWrapper.cs
+++ b/Assets/Scripts/Ability System/AbilityWrappers/BlinkDaggerAbilityWrapper.cs
@@ -2,5 +2,5 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-[CreateAssetMenu]
+[CreateAssetMenu(fileName = "Blink Dagger Wrapper", menuName = "Ability Wrappers/Blink Dagger")]
 public class BlinkDaggerAbilityWrapper : AbilityWrapper {}

--- a/Assets/Scripts/Ability System/AbilityWrappers/BlinkDaggerAbilityWrapper.cs.meta
+++ b/Assets/Scripts/Ability System/AbilityWrappers/BlinkDaggerAbilityWrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 537c85cce35073f43ae081edbcef38ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Ability System/AbilityWrappers/DashAbilityWrapper.cs
+++ b/Assets/Scripts/Ability System/AbilityWrappers/DashAbilityWrapper.cs
@@ -2,5 +2,5 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-[CreateAssetMenu]
+[CreateAssetMenu(fileName = "Dash Ability Wrapper", menuName = "Ability Wrappers/Dash")]
 public class DashAbilityWrapper : AbilityWrapper {}

--- a/Assets/Scripts/Ability System/AbilityWrappers/DashAbilityWrapper.cs
+++ b/Assets/Scripts/Ability System/AbilityWrappers/DashAbilityWrapper.cs
@@ -1,0 +1,6 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu]
+public class DashAbilityWrapper : AbilityWrapper {}

--- a/Assets/Scripts/Ability System/AbilityWrappers/DashAbilityWrapper.cs.meta
+++ b/Assets/Scripts/Ability System/AbilityWrappers/DashAbilityWrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ce8c89705e75294fbcf03117eb7dd5c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Ability System/AbilityWrappers/ProjectileAbilityWrapper.cs
+++ b/Assets/Scripts/Ability System/AbilityWrappers/ProjectileAbilityWrapper.cs
@@ -1,0 +1,6 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "Projectile Ability Wrapper", menuName = "Ability Wrappers/Projectile")]
+public class ProjectileAbilityWrapper : AbilityWrapper {}

--- a/Assets/Scripts/Ability System/AbilityWrappers/ProjectileAbilityWrapper.cs.meta
+++ b/Assets/Scripts/Ability System/AbilityWrappers/ProjectileAbilityWrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8758510c72d90c47874e8a5fae182c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Ability System/AbilityWrappers/RayCastAbilityWrapper.cs
+++ b/Assets/Scripts/Ability System/AbilityWrappers/RayCastAbilityWrapper.cs
@@ -1,0 +1,6 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "Ray Cast Ability Wrapper", menuName = "Ability Wrappers/Ray Cast")]
+public class RayCastAbilityWrapper : AbilityWrapper {}

--- a/Assets/Scripts/Ability System/AbilityWrappers/RayCastAbilityWrapper.cs.meta
+++ b/Assets/Scripts/Ability System/AbilityWrappers/RayCastAbilityWrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e1af4305abedd294294f103825f4d0c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Ability System/BlinkDaggerAbility.cs
+++ b/Assets/Scripts/Ability System/BlinkDaggerAbility.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-[CreateAssetMenu]
 public class BlinkDaggerAbility : ProjectileAbility
 {
     //private Camera mainCam;

--- a/Assets/Scripts/Ability System/SlotClass.cs
+++ b/Assets/Scripts/Ability System/SlotClass.cs
@@ -5,13 +5,13 @@ using UnityEngine;
 [System.Serializable]
 public class SlotClass
 {
-    [SerializeField] private Ability ability;
+    [SerializeField] private AbilityWrapper ability;
     
     public SlotClass() {
         ability = null;
     }
 
-    public SlotClass (Ability ability) {
+    public SlotClass (AbilityWrapper ability) {
         this.ability = ability;
     }
 
@@ -19,15 +19,19 @@ public class SlotClass
         this.ability = slot.GetAbility();
     }
 
-    public Ability GetAbility() {
+    public AbilityWrapper GetAbility() {
         return ability;
     }
     
-    public void AddAbility(Ability ability) {
+    public void AddAbility(AbilityWrapper ability) {
         this.ability = ability;
     }
 
     public void Clear() {
         this.ability = null;
+    }
+
+    public bool isClear() {
+        return this.ability == null;
     }
 }

--- a/Assets/Scripts/Augment System/AugmentManager.cs
+++ b/Assets/Scripts/Augment System/AugmentManager.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 
 public class AugmentManager : MonoBehaviour
 {
+
+    [SerializeField] private bool DEBUG = false;
+
     [SerializeField]
     private Entity current;
 
@@ -73,48 +76,23 @@ public class AugmentManager : MonoBehaviour
     }
 
     public void addAugment(Augment augment) {
-        Debug.Log("Adding augment");
-        Debug.Log(augment.GetType());
+        if (DEBUG) Debug.Log("Adding augment");
+        if (DEBUG) Debug.Log(augment.GetType());
         if (augment is OnHitAugment) {
-            Debug.Log("Adding OnHitAugment");
+            if (DEBUG) Debug.Log("Adding OnHitAugment");
             onHitAugments.Add((OnHitAugment)augment);
         }
         if (augment is ListenerAugment) {
-            Debug.Log("Adding ListenerAugment");
+            if (DEBUG) Debug.Log("Adding ListenerAugment");
             listenerAugments.Add((ListenerAugment)augment);
         }
     }
 
     public void clearAugments() {
-        Debug.Log("[Augment Manager] Clearing all augments");
+        if (DEBUG) Debug.Log("[Augment Manager] Clearing all augments");
         onHitAugments.Clear();
         listenerAugments.Clear();
 
     }
-
-    // public void addOnHitAugment(OnHitAugment augment)
-    // {
-    //     onHitAugments.Add(augment);
-    // }
-
-    // // deactive on hit augments
-    // public void removeAugment(OnHitAugment augment)
-    // {
-    //     onHitAugments.Remove(augment);
-    // }
-
-    // // add active augments
-    public void addListenerAugment(ListenerAugment augment)
-    {
-        listenerAugments.Add(augment);
-    }
-
-    // // deactive augments
-    // public void removeListenerAugment(ListenerAugment augment)
-    // {
-    //     listenerAugments.Remove(augment);
-    // }
-
-
 
 }

--- a/Assets/Scripts/Augment System/AugmentManager.cs
+++ b/Assets/Scripts/Augment System/AugmentManager.cs
@@ -30,6 +30,10 @@ public class AugmentManager : MonoBehaviour
         }
     }
 
+    public void stopAllCoroutines() {
+        StopAllCoroutines();
+    }
+
     public void setCurrent(Entity current)
     {
         this.current = current;
@@ -68,30 +72,49 @@ public class AugmentManager : MonoBehaviour
         }
     }
 
-
-    // add active on hit augments
-    public void addOnHitAugment(OnHitAugment augment)
-    {
-        onHitAugments.Add(augment);
+    public void addAugment(Augment augment) {
+        Debug.Log("Adding augment");
+        Debug.Log(augment.GetType());
+        if (augment is OnHitAugment) {
+            Debug.Log("Adding OnHitAugment");
+            onHitAugments.Add((OnHitAugment)augment);
+        }
+        if (augment is ListenerAugment) {
+            Debug.Log("Adding ListenerAugment");
+            listenerAugments.Add((ListenerAugment)augment);
+        }
     }
 
-    // deactive on hit augments
-    public void removeAugment(OnHitAugment augment)
-    {
-        onHitAugments.Remove(augment);
+    public void clearAugments() {
+        Debug.Log("[Augment Manager] Clearing all augments");
+        onHitAugments.Clear();
+        listenerAugments.Clear();
+
     }
 
-    // add active augments
+    // public void addOnHitAugment(OnHitAugment augment)
+    // {
+    //     onHitAugments.Add(augment);
+    // }
+
+    // // deactive on hit augments
+    // public void removeAugment(OnHitAugment augment)
+    // {
+    //     onHitAugments.Remove(augment);
+    // }
+
+    // // add active augments
     public void addListenerAugment(ListenerAugment augment)
     {
         listenerAugments.Add(augment);
     }
 
-    // deactive augments
-    public void removeListenerAugment(ListenerAugment augment)
-    {
-        listenerAugments.Remove(augment);
-    }
+    // // deactive augments
+    // public void removeListenerAugment(ListenerAugment augment)
+    // {
+    //     listenerAugments.Remove(augment);
+    // }
+
 
 
 }

--- a/Assets/Scripts/Augment System/DebugToggleAugments.cs
+++ b/Assets/Scripts/Augment System/DebugToggleAugments.cs
@@ -12,7 +12,10 @@ public class DebugToggleAugments : MonoBehaviour
     {
         this.augmentManager = gameObject.GetComponent<AugmentManager>();
     }
-    // Update is called once per frame
+    /**
+     * Add this to Player and use Space Bar to toggle coroutines
+     * After we have a proper system for runs we can scrap this
+     **/
     void Update()
     {
         if (Input.GetKeyDown(KeyCode.Space))

--- a/Assets/Scripts/Augment System/DebugToggleAugments.cs
+++ b/Assets/Scripts/Augment System/DebugToggleAugments.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+public class DebugToggleAugments : MonoBehaviour
+{
+    [SerializeField]
+    private AugmentManager augmentManager;
+    
+    private bool active = false;
+
+    private void Awake()
+    {
+        this.augmentManager = gameObject.GetComponent<AugmentManager>();
+    }
+    // Update is called once per frame
+    void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Space))
+        {
+            if (!active) {
+                Debug.Log("Starting Coroutines");
+                augmentManager.startCoroutines();
+                active = !active;
+            }
+            else {
+                Debug.Log("Stopping Coroutines");
+                augmentManager.stopAllCoroutines();
+                active = !active;
+            } 
+        }
+    }
+}

--- a/Assets/Scripts/Augment System/DebugToggleAugments.cs.meta
+++ b/Assets/Scripts/Augment System/DebugToggleAugments.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6818fdf07ab87dc45b472730d09a4fc3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Augment System/OnHitAugment.cs
+++ b/Assets/Scripts/Augment System/OnHitAugment.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class OnHitAugment : Augment
 {
+    
     public virtual float applyAugmentDamageTaken(float damageTaken, Entity current, Entity target)
     {
         // used in AugmentManager to actually apply

--- a/Assets/Scripts/Augment System/TestAugment.cs
+++ b/Assets/Scripts/Augment System/TestAugment.cs
@@ -22,7 +22,7 @@ public class TestAugment : MonoBehaviour
         if (Input.GetKeyDown(KeyCode.Space))
         {
             listener.enableAugment();
-            augmentManager.addListenerAugment(listener);
+            augmentManager.addAugment(listener);
             augmentManager.startCoroutines();
         }
     }

--- a/Assets/Scripts/Entities/Entity.cs
+++ b/Assets/Scripts/Entities/Entity.cs
@@ -44,7 +44,7 @@ public class Entity : MonoBehaviour
     public virtual void Die() {
         if(_isDead) return;
         //override in child classes
-        Debug.Log("dead");
+        //Debug.Log("dead");
     }
 
     // relaying data to augment manager


### PR DESCRIPTION
## Draft PR to keep track of current changes

- AbilityInventoryManager now works with AbilityWrappers instead of Abilities
- AbilityInventoryManager now updates passives upon moving stuff
- Added a Debug Script that toggles Coroutines on space press (while we don't have a code for run structure)

#### Things that still need doing
- ~~Rethink Augments to remove the ugly upcasting that's currently there to discern augment types~~ This is probably fine
- Add code to enable/disable coroutines and on-hit passives (won't be used immediately, but will be needed in the future)
- Remake template scene to support Ability Wrappers
- Small documentation for Ability Wrappers so people know how to make them
- Testing, testing, testing. *This has the potential to break a lot of stuff*
- Cleanup